### PR TITLE
STATION13｜スクリーンの増設に対応しよう

### DIFF
--- a/app/controllers/admin/schedules_controller.rb
+++ b/app/controllers/admin/schedules_controller.rb
@@ -61,6 +61,6 @@ class Admin::SchedulesController < ApplicationController
   
     # 許可されたパラメータのみを取得（セキュリティ対策）
     def schedule_params
-      params.require(:schedule).permit(:start_time, :end_time)
+      params.require(:schedule).permit(:start_time, :end_time, :screen_id)
     end
   end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -40,16 +40,22 @@ class MoviesController < ApplicationController
 
       @movie = Movie.find(params[:movie_id])
       @schedule = Schedule.find(params[:schedule_id])
-      @sheets= Sheet.all
-
       # スケジュールに関連するスクリーンの座席を取得
       @sheets = Sheet.where(screen_id: @schedule.screen_id)
       # デバッグ用ログ出力
       Rails.logger.debug "Sheets for Screen #{@schedule.screen_id}: #{@sheets.map { |s| "#{s.row}-#{s.column}" }.join(', ')}"
 
       @reserved_sheets = Reservation.where(
-        date: params[:date],
-        schedule_id: params[:schedule_id]
+        schedule_id: params[:schedule_id],
+        # screen_id: @schedule.screen_id,
+        sheet_id: @sheets.pluck(:id),
+        date: Date.parse(params[:date]) # `params[:date]` を `Date` 型に変換
         ).pluck(:sheet_id)
+
+        # デバック用コード
+        puts "Schedule ID: #{@schedule.id}, Expected: #{params[:schedule_id]}"
+        puts "Date Type: #{params[:date].class}, Expected: String"
+        puts "Sheets for Screen #{@schedule.screen_id}: #{@sheets.map { |s| "#{s.row}-#{s.column}" }.join(', ')}"
+        puts "Reservations Found: #{@reserved_sheets}"
     end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -41,6 +41,12 @@ class MoviesController < ApplicationController
       @movie = Movie.find(params[:movie_id])
       @schedule = Schedule.find(params[:schedule_id])
       @sheets= Sheet.all
+
+      # スケジュールに関連するスクリーンの座席を取得
+      @sheets = Sheet.where(screen_id: @schedule.screen_id)
+      # デバッグ用ログ出力
+      Rails.logger.debug "Sheets for Screen #{@schedule.screen_id}: #{@sheets.map { |s| "#{s.row}-#{s.column}" }.join(', ')}"
+
       @reserved_sheets = Reservation.where(
         date: params[:date],
         schedule_id: params[:schedule_id]

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -7,10 +7,13 @@ class ReservationsController < ApplicationController
     @reservation = Reservation.new
     @movie = Movie.find(params[:movie_id])
     @schedule = Schedule.find(params[:schedule_id])
-    @sheet = Sheet.find(params[:sheet_id])
-
-    # スケジュールに関連するスクリーンの座席を取得
+    
+    # スケジュールに関連するスクリーンの座席を取得（これを先にやる）
     @sheets = Sheet.where(screen_id: @schedule.screen_id)
+    
+    # 取得した座席のリストから、指定された `sheet_id` の座席を探す
+    @sheet = @sheets.find_by(id: params[:sheet_id]) 
+    
 
     # デバッグ用ログ出力
     Rails.logger.debug "Sheets for Screen #{@schedule.screen_id}: #{@sheets.map { |s| "#{s.row}-#{s.column}" }.join(', ')}"

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -9,6 +9,12 @@ class ReservationsController < ApplicationController
     @schedule = Schedule.find(params[:schedule_id])
     @sheet = Sheet.find(params[:sheet_id])
 
+    # スケジュールに関連するスクリーンの座席を取得
+    @sheets = Sheet.where(screen_id: @schedule.screen_id)
+
+    # デバッグ用ログ出力
+    Rails.logger.debug "Sheets for Screen #{@schedule.screen_id}: #{@sheets.map { |s| "#{s.row}-#{s.column}" }.join(', ')}"
+
     if Reservation.exists?(schedule_id: @schedule.id, sheet_id: @sheet.id, date: params[:date])
       redirect_to movie_reservation_path(@movie, schedule_id: @schedule.id, date: params[:date]), alert: "その座席はすでに予約済みです。" and return
     end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,5 +1,8 @@
 class Schedule < ApplicationRecord
+  belongs_to :screen
   belongs_to :movie
+  has_many :reservations
   validates :start_time, presence: true
   validates :end_time, presence: true
+  validates :screen_id, presence: true
 end

--- a/app/models/screen.rb
+++ b/app/models/screen.rb
@@ -1,0 +1,5 @@
+class Screen < ApplicationRecord
+    has_many :sheets
+    has_many :schedules
+    validates :name, presence: true, uniqueness: true
+  end

--- a/app/models/sheet.rb
+++ b/app/models/sheet.rb
@@ -1,5 +1,7 @@
 class Sheet < ApplicationRecord
+    belongs_to :screen
     has_many :reservations
     validates :column, presence: true, numericality: { only_integer: true }
     validates :row, presence: true, length: { is: 1 }
+    validates :screen_id, presence: true
 end

--- a/app/views/admin/schedules/new.html.erb
+++ b/app/views/admin/schedules/new.html.erb
@@ -11,6 +11,12 @@
       </ul>
     </div>
   <% end %>
+  
+  <div>
+    <label>スクリーン:</label>
+    <%= f.collection_select :screen_id, Screen.all, :id, :name, { prompt: "スクリーンを選択してください" }, { required: true } %>
+  </div>
+
 
   <div class="field">
     <%= f.label :start_time, "開始時刻" %>

--- a/app/views/admin/schedules/show.html.erb
+++ b/app/views/admin/schedules/show.html.erb
@@ -3,6 +3,7 @@
 
 <p>作品ID: <%= @schedule.movie.id %></p>
 <p>作品名: <%= @schedule.movie.name %></p>
+<p>スクリーン: <%= @schedule.screen.name %></p>
 <p>開始時刻: <%= @schedule.start_time.strftime("%H:%M") %></p>
 <p>終了時刻: <%= @schedule.end_time.strftime("%H:%M") %></p>
 <p>作成日時: <%= @schedule.created_at %></p>

--- a/app/views/movies/reservation.html.erb
+++ b/app/views/movies/reservation.html.erb
@@ -1,5 +1,7 @@
 <h1>座席表 - <%= @movie.name %> (<%= params[:date] %>)</h1>
 
+<p>予約済みの座席: <%= @reserved_sheets.inspect %></p>
+
 <table border="1">
   <% @sheets.group_by(&:row).each do |row, sheets| %>
     <tr>

--- a/db/migrate/20250224092120_create_screens.rb
+++ b/db/migrate/20250224092120_create_screens.rb
@@ -1,0 +1,9 @@
+class CreateScreens < ActiveRecord::Migration[7.1]
+  def change
+    create_table :screens do |t|
+      t.string :name, null: false
+      t.timestamps
+    end
+    add_index :screens, :name, unique: true
+  end
+end

--- a/db/migrate/20250224092458_add_screen_id_to_sheets.rb
+++ b/db/migrate/20250224092458_add_screen_id_to_sheets.rb
@@ -1,0 +1,16 @@
+class AddScreenIdToSheets < ActiveRecord::Migration[7.1]
+  def up
+    add_reference :sheets, :screen, null: true, foreign_key: true
+    
+    Screen.transaction do
+      screen = Screen.find_or_create_by!(name: 'スクリーン1')
+      Sheet.update_all(screen_id: screen.id)
+      change_column_null :sheets, :screen_id, false
+    end
+  end
+
+  def down
+    remove_foreign_key :sheets, :screens
+    remove_reference :sheets, :screen
+  end
+end

--- a/db/migrate/20250224092530_add_screen_id_to_schedules.rb
+++ b/db/migrate/20250224092530_add_screen_id_to_schedules.rb
@@ -1,0 +1,16 @@
+class AddScreenIdToSchedules < ActiveRecord::Migration[7.1]
+  def up
+    add_reference :schedules, :screen, null: true, foreign_key: true
+    
+    Screen.transaction do
+      screen = Screen.first || Screen.create!(name: 'スクリーン1')
+      Schedule.update_all(screen_id: screen.id)
+      change_column_null :schedules, :screen_id, false
+    end
+  end
+
+  def down
+    remove_foreign_key :schedules, :screens
+    remove_reference :schedules, :screen
+  end
+end

--- a/db/migrate/20250224121806_add_screen_id_to_reservations.rb
+++ b/db/migrate/20250224121806_add_screen_id_to_reservations.rb
@@ -1,0 +1,23 @@
+class AddScreenIdToReservations < ActiveRecord::Migration[7.1]
+  def up
+    add_reference :reservations, :screen, null: true, foreign_key: true
+
+    # 既存のデータに `screen_id` を適切に設定
+    Reservation.find_each do |reservation|
+      schedule = Schedule.find_by(id: reservation.schedule_id)
+      if schedule
+        reservation.update!(screen_id: schedule.screen_id)
+      else
+        raise "予約 ID: #{reservation.id} に対応するスケジュールが見つかりません"
+      end
+    end
+
+    # `screen_id` を NULL 不可にする
+    change_column_null :reservations, :screen_id, false
+  end
+
+  def down
+    remove_foreign_key :reservations, :screens
+    remove_reference :reservations, :screen
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_24_092530) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_24_121806) do
   create_table "movies", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", limit: 160, null: false, comment: "映画のタイトル。邦題・洋題は一旦考えなくてOK"
     t.string "year", limit: 45, comment: "公開年"
@@ -30,8 +30,10 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_24_092530) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "screen_id", null: false
     t.index ["date", "schedule_id", "sheet_id"], name: "index_reservations_on_date_and_schedule_id_and_sheet_id", unique: true
     t.index ["schedule_id"], name: "index_reservations_on_schedule_id"
+    t.index ["screen_id"], name: "index_reservations_on_screen_id"
     t.index ["sheet_id"], name: "index_reservations_on_sheet_id"
   end
 
@@ -63,6 +65,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_24_092530) do
   end
 
   add_foreign_key "reservations", "schedules"
+  add_foreign_key "reservations", "screens"
   add_foreign_key "reservations", "sheets"
   add_foreign_key "schedules", "movies"
   add_foreign_key "schedules", "screens"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_22_072717) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_24_092530) do
   create_table "movies", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", limit: 160, null: false, comment: "映画のタイトル。邦題・洋題は一旦考えなくてOK"
     t.string "year", limit: 45, comment: "公開年"
@@ -41,7 +41,16 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_22_072717) do
     t.time "end_time", null: false, comment: "上映終了時刻"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "screen_id", null: false
     t.index ["movie_id"], name: "index_schedules_on_movie_id"
+    t.index ["screen_id"], name: "index_schedules_on_screen_id"
+  end
+
+  create_table "screens", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_screens_on_name", unique: true
   end
 
   create_table "sheets", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -49,9 +58,13 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_22_072717) do
     t.string "row", limit: 1, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "screen_id", null: false
+    t.index ["screen_id"], name: "index_sheets_on_screen_id"
   end
 
   add_foreign_key "reservations", "schedules"
   add_foreign_key "reservations", "sheets"
   add_foreign_key "schedules", "movies"
+  add_foreign_key "schedules", "screens"
+  add_foreign_key "sheets", "screens"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,10 +7,21 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+# IDを指定せずにシードデータを登録し、一貫性を保つ
+screen1 = Screen.find_or_create_by!(name: 'スクリーン1')
+screen2 = Screen.find_or_create_by!(name: 'スクリーン2')
+screen3 = Screen.find_or_create_by!(name: 'スクリーン3')
 
-# 座席マスターデータ
-Sheet.create!([
-    { column: 1, row: 'a' }, { column: 2, row: 'a' }, { column: 3, row: 'a' }, { column: 4, row: 'a' }, { column: 5, row: 'a' },
-    { column: 1, row: 'b' }, { column: 2, row: 'b' }, { column: 3, row: 'b' }, { column: 4, row: 'b' }, { column: 5, row: 'b' },
-    { column: 1, row: 'c' }, { column: 2, row: 'c' }, { column: 3, row: 'c' }, { column: 4, row: 'c' }, { column: 5, row: 'c' }
-])
+# 座席マスターデータ（全スクリーン共通）
+sheets = [
+  { column: 1, row: 'a' }, { column: 2, row: 'a' }, { column: 3, row: 'a' }, { column: 4, row: 'a' }, { column: 5, row: 'a' },
+  { column: 1, row: 'b' }, { column: 2, row: 'b' }, { column: 3, row: 'b' }, { column: 4, row: 'b' }, { column: 5, row: 'b' },
+  { column: 1, row: 'c' }, { column: 2, row: 'c' }, { column: 3, row: 'c' }, { column: 4, row: 'c' }, { column: 5, row: 'c' }
+]
+
+# 各スクリーンに対して座席データを作成
+[screen1, screen2, screen3].each do |screen|
+  sheets.each do |sheet|
+    Sheet.find_or_create_by!(column: sheet[:column], row: sheet[:row], screen_id: screen.id)
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,12 +5,12 @@
 # Example:
 #
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
+#     MovieGenre.first_or_create!(name: genre_name)
 #   end
 # IDを指定せずにシードデータを登録し、一貫性を保つ
-screen1 = Screen.find_or_create_by!(name: 'スクリーン1')
-screen2 = Screen.find_or_create_by!(name: 'スクリーン2')
-screen3 = Screen.find_or_create_by!(name: 'スクリーン3')
+screen1 = Screen.first_or_create!(name: 'スクリーン1')
+screen2 = Screen.first_or_create!(name: 'スクリーン2')
+screen3 = Screen.first_or_create!(name: 'スクリーン3')
 
 # 座席マスターデータ（全スクリーン共通）
 sheets = [
@@ -22,6 +22,6 @@ sheets = [
 # 各スクリーンに対して座席データを作成
 [screen1, screen2, screen3].each do |screen|
   sheets.each do |sheet|
-    Sheet.find_or_create_by!(column: sheet[:column], row: sheet[:row], screen_id: screen.id)
+    Sheet.first_or_create!(column: sheet[:column], row: sheet[:row], screen_id: screen.id)
   end
 end

--- a/docs/devlooment_note/ station13-実装方針.md
+++ b/docs/devlooment_note/ station13-実装方針.md
@@ -1,0 +1,207 @@
+# **スクリーン増設対応の実装手順（最終版）**
+
+## **前提条件**
+- スクリーンが1つから3つに増設
+- ユーザー向けUIは変更なし
+- 同じ座席番号でもスクリーンが異なれば予約可能
+- スクリーン情報はユーザーには非表示
+
+---
+
+## **1. スクリーンモデルとマイグレーションの作成**
+
+```bash
+docker compose exec web rails generate model Screen name:string
+```
+
+### **📌 `app/models/screen.rb`**
+```ruby
+class Screen < ApplicationRecord
+  has_many :sheets
+  has_many :schedules
+  validates :name, presence: true, uniqueness: true
+end
+```
+
+### **📌 `db/migrate/XXXXXXXXXXXXXX_create_screens.rb`**
+```ruby
+class CreateScreens < ActiveRecord::Migration[7.1]
+  def change
+    create_table :screens do |t|
+      t.string :name, null: false
+      t.timestamps
+    end
+    add_index :screens, :name, unique: true
+  end
+end
+```
+
+---
+
+## **2. 既存テーブルへのスクリーンID追加**
+
+```bash
+docker compose exec web rails generate migration AddScreenIdToSheets screen:references
+docker compose exec web rails generate migration AddScreenIdToSchedules screen:references
+```
+
+### **📌 `db/migrate/XXXXXXXXXXXXXX_add_screen_id_to_sheets.rb`**
+```ruby
+class AddScreenIdToSheets < ActiveRecord::Migration[7.1]
+  def up
+    add_reference :sheets, :screen, null: true, foreign_key: true
+    
+    Screen.transaction do
+      screen = Screen.find_or_create_by!(name: 'スクリーン1')
+      Sheet.update_all(screen_id: screen.id)
+      change_column_null :sheets, :screen_id, false
+    end
+  end
+
+  def down
+    remove_foreign_key :sheets, :screens
+    remove_reference :sheets, :screen
+  end
+end
+```
+
+### **📌 `db/migrate/XXXXXXXXXXXXXX_add_screen_id_to_schedules.rb`**
+```ruby
+class AddScreenIdToSchedules < ActiveRecord::Migration[7.1]
+  def up
+    add_reference :schedules, :screen, null: true, foreign_key: true
+    
+    Screen.transaction do
+      screen = Screen.find_or_create_by!(name: 'スクリーン1')
+      Schedule.update_all(screen_id: screen.id)
+      change_column_null :schedules, :screen_id, false
+    end
+  end
+
+  def down
+    remove_foreign_key :schedules, :screens
+    remove_reference :schedules, :screen
+  end
+end
+```
+
+✅ **修正点**
+- **`down` メソッドで `foreign_key` の削除を明示的に実施**
+- **トランザクションを使用し、データ整合性を確保**
+
+---
+
+## **3. 関連モデルの修正**
+
+### **📌 `app/models/sheet.rb`**
+```ruby
+class Sheet < ApplicationRecord
+  belongs_to :screen
+  has_many :reservations
+
+  validates :screen_id, presence: true
+end
+```
+
+### **📌 `app/models/schedule.rb`**
+```ruby
+class Schedule < ApplicationRecord
+  belongs_to :screen
+  belongs_to :movie
+  has_many :reservations
+
+  validates :screen_id, presence: true
+end
+```
+
+✅ **修正点**
+- **`screen_id` の `presence: true` を追加し、アプリケーションレイヤーで整合性を保証**
+
+---
+
+## **4. マイグレーションの実行**
+
+```bash
+docker compose exec web rails db:migrate
+docker compose exec web rails db:migrate:status  # 適用状況を確認
+```
+
+✅ **修正点**
+- **`rails db:migrate:status` を追加し、適用状況をチェックできるように修正**
+
+---
+
+## **5. スクリーンデータの追加**
+
+### **📌 `db/seeds.rb`**
+```ruby
+# スクリーンデータを登録
+Screen.first_or_create!(name: 'スクリーン1')
+Screen.first_or_create!(name: 'スクリーン2')
+Screen.first_or_create!(name: 'スクリーン3')
+
+# 座席データを各スクリーンに登録
+Screen.all.each do |screen|
+  ('a'..'c').each do |row|
+    (1..5).each do |column|
+      Sheet.find_or_create_by!(row: row, column: column, screen: screen)
+    end
+  end
+end
+```
+
+```bash
+docker compose exec web rails db:seed
+```
+
+✅ **修正点**
+- **`find_or_create_by!` から `first_or_create!` に変更し、並列処理時の競合を防止**
+- **各スクリーンに座席データを登録**
+
+---
+
+## **6. リザベーションコントローラーの実装**
+
+### **📌 `app/controllers/reservations_controller.rb`**
+```ruby
+class ReservationsController < ApplicationController
+  def new
+    if params[:date].blank? || params[:sheet_id].blank?
+      redirect_to movie_reservation_path(params[:movie_id], schedule_id: params[:schedule_id], date: params[:date]), alert: "座席を選択してください。" and return
+    end
+
+    @reservation = Reservation.new
+    @movie = Movie.find(params[:movie_id])
+    @schedule = Schedule.find(params[:schedule_id])
+
+    # スケジュールに関連するスクリーンの座席のみ取得
+    @sheets = Sheet.where(screen_id: @schedule.screen_id)
+
+    # 座席を取得（スクリーンIDを考慮）
+    @sheet = @sheets.find_by(id: params[:sheet_id])
+
+    if @sheet.nil?
+      redirect_to movie_reservation_path(@movie, schedule_id: @schedule.id, date: params[:date]), alert: "無効な座席です。" and return
+    end
+
+    if Reservation.exists?(schedule_id: @schedule.id, sheet_id: @sheet.id, date: params[:date])
+      redirect_to movie_reservation_path(@movie, schedule_id: @schedule.id, date: params[:date]), alert: "その座席はすでに予約済みです。" and return
+    end
+  end
+end
+```
+
+✅ **修正点**
+- **スケジュールに関連するスクリーンの座席を取得**
+- **誤ったスクリーンの座席が指定された場合の処理を追加**
+
+---
+
+## **7. 重要なポイント**
+✅ **トランザクションを利用し、マイグレーション時のデータ整合性を保証**  
+✅ **ActiveRecord を利用して `update_all` を実行し、DB 依存を排除**  
+✅ **モデルレベルで `screen_id` の `presence: true` を追加し、整合性を確保**  
+✅ **`foreign_key` の削除を `down` メソッドで明示的に実施**  
+✅ **シードデータの `id` 指定を削除し、`AUTO_INCREMENT` の整合性を維持**  
+✅ **マイグレーション適用後に `rails db:migrate:status` で適用状況をチェック**  
+✅ **リザベーションコントローラーでスクリーンに関連する座席を正しく取得**

--- a/spec/factories/screens.rb
+++ b/spec/factories/screens.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :screen do
+    sequence(:name) { |n| "スクリーン#{n}" }
+  end
+end

--- a/spec/models/screen_spec.rb
+++ b/spec/models/screen_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Screen, type: :model do
+  describe 'validations' do
+    it { should validate_presence_of(:name) }
+    it { should validate_uniqueness_of(:name) }
+  end
+
+  describe 'associations' do
+    it { should have_many(:sheets) }
+    it { should have_many(:schedules) }
+  end
+
+  describe 'factory' do
+    it 'has a valid factory' do
+      expect(build(:screen)).to be_valid
+    end
+  end
+end


### PR DESCRIPTION
# 🎬 スクリーン増設対応の実装

## 📝 変更の概要

### 背景
- スクリーンを1つから3つに増設することになった。
- 現状の予約機能ではスクリーンの区別がなく、異なるスクリーンでも同じ座席を予約済みと判定してしまう問題が発生。
- スクリーンごとに適切に座席管理を行う必要がある。

### 解決策
- **`screens` テーブルを追加** し、スクリーン情報を管理。
- **`sheets`（座席）と `schedules`（上映スケジュール）に `screen_id` を追加**。
- **予約時に `screen_id` を考慮** し、異なるスクリーンの座席は別のものとして判定。
- **マイグレーション時のデータ整合性を確保** しつつ、既存の予約データを適切に修正。

## 🔍 変更の詳細

### 主な追加機能
- **スクリーン管理**
  - `screens` テーブルの追加（スクリーン情報の管理）
  - 既存の `sheets`・`schedules`・`reservations` に `screen_id` を追加
  - スクリーン情報を適切に設定するシードデータの追加

- **座席予約の修正**
  - 予約時に `screen_id` を考慮する
  - **異なるスクリーンでの座席予約を可能にする**
  - **予約済みの座席を適切に取得し、グレーアウト表示を復活させる**

- **データ整合性の向上**
  - `reservations` の `screen_id` は `schedule_id` から取得
  - `find_or_create_by!` を使用し、マイグレーション時のデータ不整合を防ぐ
  - `foreign_key` を適切に設定し、関連性を保証

### 技術的な実装
- `screens` テーブルの追加によるスキーマ変更
- `sheets`・`schedules`・`reservations` への `screen_id` 追加
- **ActiveRecord の関連付け修正**
  - `belongs_to :screen` を `sheets`・`schedules`・`reservations` に追加
  - `has_many :sheets, :schedules` を `screens` に追加
- **マイグレーション時のデータ更新**
  - `update_all(screen_id: schedule.screen_id)` を用いてデータの一貫性を確保
  - `change_column_null :reservations, :screen_id, false` を適用

## ✅ テスト方法

### テストの実行
```bash
docker compose exec web bundle exec rspec ./spec/station13
```

### 動作確認項目
- [ ] 予約済みの座席が正しくグレーアウト表示されること。
- [ ] 異なるスクリーンでの同一座席予約が可能であること。
- [x] スクリーンごとに座席を管理できていること。
- [x] 既存の予約データが正しく引き継がれていること。
- [x] 新規予約が正常に作成できること。
- [x] 既存のUIに影響を与えず、動作が維持されていること。

## 📋 レビューのポイント
- スクリーン情報の適切な管理
- 予約済み座席の取得ロジックの修正
- データ整合性の確保
- ユーザーへの影響を最小限に抑えた実装